### PR TITLE
added curl, use alpine as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,12 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
 ####################################################################################################
 ## Final image
 ####################################################################################################
-FROM scratch
+FROM alpine:latest
 
 # Import from builder.
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group
+RUN apk add curl
 
 WORKDIR /app
 


### PR DESCRIPTION
added CURL for healthchecks, use alpine as base image

this addresses [hasura/graphql-engine#9964](https://github.com/hasura/graphql-engine/issues/9964)

CURL is used for healthchecks

alpine is needed to allow http requests, I beleive this is due to a dependency.
I do not know the details, but the scratch image fails to make http requests, while alpine works.

TODO: check perf vs a larger, ubuntu based image.