### PR TITLE
bump package version to sync with HGE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "clickhouse_gdc"
-version = "0.4.2"
+version = "2.35.0"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse_gdc"
-version = "0.4.2"
+version = "2.35.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+## 2.35.0
+
+- Update docker build process to produce small, alpine-based images
+- update version number to match HGE version. Going forward will try to keep major and minor version in sync. Patch version will be independent.
+
 ## 0.4.2
 
 - Improve error handling requests to clickhouse db


### PR DESCRIPTION
sync up package version with graphql engine.

Going forward, major and minor versions should be the same as those of HGE.

This also indicates compatibility.
Patch version will change independently.