### PR TITLE
Fix-introspection

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "clickhouse_gdc"
-version = "2.35.1"
+version = "2.35.2"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse_gdc"
-version = "2.35.1"
+version = "2.35.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # ChangeLog
 
+## 2.35.2
+
+- fix introspection 2: only query for base tables and views
+
 ## 2.35.1
 
 - fix introspection

--- a/src/server/routes/introspection/basic_info_filtered.sql
+++ b/src/server/routes/introspection/basic_info_filtered.sql
@@ -3,5 +3,6 @@ SELECT
     tables.table_type AS "table_type"
 FROM INFORMATION_SCHEMA.TABLES AS tables
 WHERE tables.table_catalog = currentDatabase()
+AND tables.table_type IN ('BASE TABLE', 'VIEW')
 AND tables.table_name IN {table_names:Array(String)}
 FORMAT JSON;

--- a/src/server/routes/introspection/basic_info_unfiltered.sql
+++ b/src/server/routes/introspection/basic_info_unfiltered.sql
@@ -3,4 +3,5 @@ SELECT
     tables.table_type AS "table_type"
 FROM INFORMATION_SCHEMA.TABLES AS tables
 WHERE tables.table_catalog = currentDatabase()
+AND tables.table_type IN ('BASE TABLE', 'VIEW')
 FORMAT JSON;

--- a/src/server/routes/introspection/everything_filtered.sql
+++ b/src/server/routes/introspection/everything_filtered.sql
@@ -33,5 +33,6 @@ LEFT JOIN (
 ) AS system_columns ON system_columns.database = tables.table_schema
 AND system_columns.table = tables.table_name
 WHERE tables.table_catalog = currentDatabase()
+AND tables.table_type IN ('BASE TABLE', 'VIEW')
 AND tables.table_name IN {table_names:Array(String)}
 FORMAT JSON;

--- a/src/server/routes/introspection/everything_unfiltered.sql
+++ b/src/server/routes/introspection/everything_unfiltered.sql
@@ -33,4 +33,5 @@ LEFT JOIN (
 ) AS system_columns ON system_columns.database = tables.table_schema
 AND system_columns.table = tables.table_name
 WHERE tables.table_catalog = currentDatabase()
+AND tables.table_type IN ('BASE TABLE', 'VIEW')
 FORMAT JSON;


### PR DESCRIPTION
added filter to only query for `BASE TABLE` and `VIEW` during introspection. This addresses [hasura/graphql-engine#9964](https://github.com/hasura/graphql-engine/issues/9964#issuecomment-1814489936) (comment)

This is ready for release