### PR TITLE
fix partial introspection of qualified table names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,7 +365,7 @@ checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
 
 [[package]]
 name = "clickhouse_gdc"
-version = "2.36.0"
+version = "2.37.1"
 dependencies = [
  "axum",
  "axum-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse_gdc"
-version = "2.36.0"
+version = "2.37.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # ChangeLog
 
-- fix introspection 4: when introspecting for specific tables, allow qualified table names. Note we only filter on talbe names with no regards for schemas, this may need to be fixed later
+- fix introspection 4: when introspecting for specific tables, allow qualified table names. Note we only filter on table names with no regards for schemas, this may need to be fixed later
 
 ## 2.36.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,7 @@
 # ChangeLog
 
+- fix introspection 4: when introspecting for specific tables, allow qualified table names. Note we only filter on talbe names with no regards for schemas, this may need to be fixed later
+
 ## 2.36.0
 
 - fix introspection 3: instead of only showing tables in the current database schema, show tables from all schema except `system` and `INFORMATION_SCHEMA`

--- a/src/server/routes/post_schema.rs
+++ b/src/server/routes/post_schema.rs
@@ -369,13 +369,13 @@ fn get_introspection_sql(
             let table_names = tables
                 .iter()
                 .map(|table_name| {
-                    if let [name] = &table_name.as_slice() {
+                    if let Some(name) = table_name.last() {
                         Ok(name.to_owned())
                     } else {
                         Err(ServerError::UncaughtError {
                             details: None,
                             message: format!(
-                                "Expected table name to be an array with one element, got {:?}",
+                                "Expected table name to be an array with at least one element, got {:?}",
                                 table_name
                             ),
                             error_type: ErrorResponseType::UncaughtError,


### PR DESCRIPTION
The connector was recently modified to allow for qualified table names, after it became apparent the previous assumptions that all clickhouse tables would always live in the `default` schema proved false.

Those changes missed that we also relied on this assumption when introspecting filtered tables, that is only fetching introspection for specific tables.

This fix changes the assumption from "table names are arrays with a single string" to "table names are arrays with at least one string". We filter using the last string in the array.

Note, this behavior is still incorrect. We now ignore the qualified part of the table name, so when asked to introspect table `schema1.table1` we would also return introspection result for `schema2.table1`

We can probably fix that too if it's a problem?